### PR TITLE
Overwrite defaultConfig with config

### DIFF
--- a/hlsServer.js
+++ b/hlsServer.js
@@ -10,7 +10,7 @@ const requestHandler = require('./requestHandler');
 class HLSServer {
   constructor (config = defaultConfig) {
     this.server = null;
-    this.config = { ...defaultConfig, ...config }; ;
+    this.config = {  ...config }; ;
     this.hlsSessions = new Map();
   }
 


### PR DESCRIPTION
Had a problem where hls_wrap was not available in ffmpeg, which lead to a problem running the application. I would suggest overwriting `defaultConfig` given a config, because otherwise it'll lead to problems such as this.

